### PR TITLE
ユーザーのパスワードをDBに登録時、暗号化するように変更

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,8 @@ gem 'jbuilder', '~> 2.7'
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'
 # Use Active Model has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
+# パスワードを暗号化するため
+gem 'bcrypt', '~> 3.1.7'
 
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,7 @@ GEM
       aws-sigv4 (~> 1.4)
     aws-sigv4 (1.5.0)
       aws-eventstream (~> 1, >= 1.0.2)
+    bcrypt (3.1.18)
     bindex (0.8.1)
     bootsnap (1.11.1)
       msgpack (~> 1.2)
@@ -330,6 +331,7 @@ PLATFORMS
 
 DEPENDENCIES
   aws-sdk-s3
+  bcrypt (~> 3.1.7)
   bootsnap (>= 1.4.4)
   bullet
   byebug

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,7 @@
 class User < ApplicationRecord
+  # users テーブルにパスワードを保存するとき、パスワードを暗号化して保存してくれる
+  has_secure_password
+
   #{}があると
   #undefined method `to_sym' for {:presence=>true}:Hashエラー文が出てしまう
   validates :name, presence:true, uniqueness: true, length: { maximum: 10 }

--- a/db/migrate/20221203111651_rename_password_column_to_users.rb
+++ b/db/migrate/20221203111651_rename_password_column_to_users.rb
@@ -1,0 +1,5 @@
+class RenamePasswordColumnToUsers < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :users, :password, :password_digest
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_10_123941) do
+ActiveRecord::Schema.define(version: 2022_12_03_111651) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -90,7 +90,7 @@ ActiveRecord::Schema.define(version: 2022_07_10_123941) do
 
   create_table "users", force: :cascade do |t|
     t.string "name"
-    t.string "password"
+    t.string "password_digest"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "email"


### PR DESCRIPTION
# 何故このような変更をしたか
- セキュリティ的に暗号化しないとよくなかったので変更


# 何をしたか
- usersテーブルのカラム名を変更 password ⇨passwor_digest
- user,Modelにhas_secure_passwordを記述
- gem追加(bcrypt)


# 動作確認
- userテーブルのパスワードを確認したら暗号化されていた